### PR TITLE
Fix so that git UI color config settings doesn't effect the git log

### DIFF
--- a/bin/git-stats-importer
+++ b/bin/git-stats-importer
@@ -51,7 +51,7 @@ myRepo.exec("config user.email", function (err, GIT_EMAIL) {
               , "max-count": "100"
               , skip: c.toString()
               , all: true
-            }, "log");
+            }, "log --no-color");
             myRepo.exec(command, function (err, data) {
                 if (err) { return Logger.log(err, "error"); }
                 if (!data) { return callback(null); }

--- a/bin/git-stats-importer
+++ b/bin/git-stats-importer
@@ -51,7 +51,8 @@ myRepo.exec("config user.email", function (err, GIT_EMAIL) {
               , "max-count": "100"
               , skip: c.toString()
               , all: true
-            }, "log --no-color");
+              , "no-color": true
+            }, "log");
             myRepo.exec(command, function (err, data) {
                 if (err) { return Logger.log(err, "error"); }
                 if (!data) { return callback(null); }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "importer"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com>",
+  "contributors": [{
+    "name": "John Clarke",
+    "email": "clarke.johnna+github@gmail.com"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/git-stats-importer/issues"


### PR DESCRIPTION
If the user has git.ui.color set in the git config, it will cause issues with not being able to match the test scenario for the sentence starting with "commit". Using the --no-color flag gets past that :)