### PR TITLE
Git mailmap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ It is supposed that `git config user.email` returns a valid value. If it doesn't
 $ git-stats-importer --delete
 ```
 
+### Using several email addresses
+Git-stats-importer relies on git's `.mailmap` feature for mapping authors. This means that, given a correct configuration, commits authored with different aliases (`user.name` and `user.email` in `.gitconfig`) can be imported just as if they had been written with your "main" `user.name`/`user.email`.
+
+To use this feature, simply configure git to use a `.mailmap` file to map commit authors ([documentation here](https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html#_mapping_authors)) and you're set !
+
 ## How to contribute
 1. File an issue in the repository, using the bug tracker, describing the
    contribution you'd like to make. This will help us to get you started on the

--- a/bin/git-stats-importer
+++ b/bin/git-stats-importer
@@ -55,6 +55,7 @@ myRepo.exec(OArgv({ _: "user.email" }, "config"), function (err, GIT_EMAIL) {
               , date: "default"
               , "max-count": "100"
               , "no-color": true
+              , "use-mailmap": true
               , __: "="
             }, "log");
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com>",
   "contributors": [
-    "John Clarke <clarke.johnna+github@gmail.com>"
+    "John Clarke <clarke.johnna+github@gmail.com>",
+    "Gnab <as0n@gnab.fr>"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This fixes issue #11 implementing `.mailmap` support in git-stats-importer. Not much to say about the implementation since it's very straight-forward.

I have also tested it with/without a git `mailmap.file` configuration and with/without an existing file at the specified location it seems to be working exactly as expected.