### PR TITLE
Import from anywhere inside a repo

### DIFF
--- a/bin/git-stats-importer
+++ b/bin/git-stats-importer
@@ -7,19 +7,27 @@ var GitStats = require("git-stats")
   , Logger = require("bug-killer")
   , Async = require("async")
   , OArgv = require("oargv")
+  , Path = require("path")
   ;
+
 
 // Configure logger
 Logger.config.displayDate = false;
 Logger.config.logLevel = 4;
 
 // Check if it's a git repo
-if (!Fs.existsSync(".git/")) {
+var repoDir = Path.resolve('.')
+  , prevDir;
+while (!Fs.existsSync(Path.resolve(repoDir, '.git/'))) {
+  prevDir = repoDir;
+  repoDir = Path.resolve(repoDir, '..');
+  if (prevDir == repoDir) {
     return Logger.log("This is not a git project.", "error");
+  }
 }
 
 // Get commits
-var myRepo = new Repo(".");
+var myRepo = new Repo(repoDir);
 myRepo.exec(OArgv({ _: "user.email" }, "config"), function (err, GIT_EMAIL) {
     GIT_EMAIL = GIT_EMAIL || process.env.GIT_AUTHOR_EMAIL;
     if (err && !GIT_EMAIL) { return Logger.log("Cannot find the git email. " + err.message, "error"); }


### PR DESCRIPTION
Current code only enables importing commits from the root directory of a repo.

This would work :
```shell
$ cd ~/[..]/my-repo
$ ls -a
. .. .git src doc
$ git-stats-importer
[...]
info Done.
```
But this would not : 
```shell
$ cd ~/[..]/my-repo/src
$ git-stats-importer
error This is not a git project.
```

But it is indeed a git project !

So I wrote this short patch which loops over the current directory's parents in search for a `.git` folder. If stops when it finds one or when it reaches the root folder (`/`).
This way we can now import commits from anywhere inside a repository, not just at it's root.

-----

**Side note** : the current implementation uses `fs.existsSync` which will eventually be deprecated ([source](http://nodejs.org/api/fs.html#fs_fs_existssync_path)). I've looked around for a replacement solution using node's standard api (mainly in [fs](http://nodejs.org/api/fs.html) and [path](http://nodejs.org/api/path.html)) but I couldn't find anything satisfying (fast and elegant).
This should probably be filed as an issue.