### PR TITLE
Count the file types for each commit so we can compile basic language statistics

### DIFF
--- a/bin/git-stats-importer
+++ b/bin/git-stats-importer
@@ -109,8 +109,10 @@ myRepo.exec(OArgv({ _: "user.email" }, "config"), function (err, GIT_EMAIL) {
                           // If we have a file changed in this commit
                           if (fileRegex.test(data[i + 6])) {
                             var languages = {};
+                            // First line of the file changes.
                             var file_start = i + 6;
-                            // Step through each file changed. The loop ends when the regex
+                            // Step through each file changed. The loop ends when the regex test returns false.
+                            // Or rather, when we get to the end of the file changes for this particular commit
                             for (file_count = 0; fileRegex.test(data[file_start + file_count]); file_count++) {
                               // Grab the file type
                               var file_type = data[file_start + file_count].match(fileRegex)[1];

--- a/bin/git-stats-importer
+++ b/bin/git-stats-importer
@@ -76,6 +76,8 @@ myRepo.exec(OArgv({ _: "user.email" }, "config"), function (err, GIT_EMAIL) {
                   , "max-count": "100"
                   , "no-color": true
                   , "use-mailmap": true
+                  // Pulling in the files changed
+                  , "name-status": true
                   , __: "="
                 }, "log");
 
@@ -101,10 +103,34 @@ myRepo.exec(OArgv({ _: "user.email" }, "config"), function (err, GIT_EMAIL) {
                           , date = getDate(i)
                           ;
 
+                          // Regex to parse the file types
+                          var fileRegex = /[^\\]*\.(\w+)$/;
+
+                          // If we have a file changed in this commit
+                          if (fileRegex.test(data[i + 6])) {
+                            var languages = {};
+                            var file_start = i + 6;
+                            // Step through each file changed. The loop ends when the regex
+                            for (file_count = 0; fileRegex.test(data[file_start + file_count]); file_count++) {
+                              // Grab the file type
+                              var file_type = data[file_start + file_count].match(fileRegex)[1];
+                              // If this file type is already defined, add 1 to it.
+                              if (languages[file_type]) {
+                                languages[file_type]++;
+                              }
+                              // New file type for this commit. Append it to our languages
+                              // Example: "php", "js", "css"
+                              else {
+                                languages[file_type] = 1;
+                              }
+                            }
+                          }
+
                         GitStats.record({
                             date: date
                           , url: REMOTE_URL
                           , hash: commitHash
+                          , languages: languages
                         }, function (err) {
                             if (err) { return Logger.log(err, "error"); }
                             Logger.log((++count) + " Imported commit: " + commitHash, "info");


### PR DESCRIPTION
My intention was to aggregate all commit data from both public/private repos that I have contributed to. The git-stats suite is exactly what I was looking for! Great work!

Language statistics was the only missing feature, so I decided to bake it in. Not sure if you want this PR, but I figured I might as well throw it out there in case you did.

https://github.com/alexknutson/git-stats/commit/34b4814fefb0c0e215e0e62fab7fce8c58d01539 is the change needed to save the languages in git-stats, but there may be other places in the git-stats codebase where it needs to be appended.

The resulting .git-stats output is:

```js
 "Jun 3, 2013": {
  "rmc7.pro:/var/www/rmc/.git": {
   "7b58dce4b0854b9b6fcc7e999b2300ad5afd147b": {
    "date": "2013-06-03T23:52:28.000Z",
    "languages": {
     "less": 1,
     "png": 2,
     "js": 1,
     "php": 1
    }
   }
  }
 }
```
