### PR TITLE
Add the color=never option to git log process

### DIFF
--- a/bin/git-stats-importer
+++ b/bin/git-stats-importer
@@ -80,6 +80,9 @@ importer.on("error", function (err, data) {
 });
 
 // Listen for finish
-importer.on("finish", function (data) {
+importer.on("finish", function (err, data) {
+    if (err) {
+        return Logger.log(err, "error");
+    }
     Logger.log("Done.");
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var GitLogParser = require("gitlog-parser").parse
   , ChildProcess = require("child_process")
   , Spawn = ChildProcess.spawn
   , GitRepos = require("git-repos")
+  , OArgv = require("oargv")
   ;
 
 /**
@@ -40,20 +41,20 @@ function Importer(options, gs, data) {
  * @return {Stream} The stdout stream of `git log` command.
  */
 Importer.prototype.stream = function () {
-    var args = ["log"]
-      , i = 0
+    var self = this
+      , args = OArgv({
+            author: this.emails
+          , color: "never"
+          , __: "="
+        }, "log")
+      , pr = Spawn(
+            "git"
+          , args
+          , { cwd: this.path }
+        )
       ;
 
-    for (; i < this.emails.length; ++i) {
-        args.push("--author");
-        args.push(this.emails[i]);
-    }
-
-    return Spawn(
-        "git"
-      , args
-      , { cwd: this.path }
-    ).stdout;
+    return pr.stdout;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "git-stats": "^2.0.0",
     "gitlog-parser": "^0.0.4",
     "gry": "^4.0.0",
-    "oargv": "^2.0.0",
+    "oargv": "^3.2.0",
     "is-there": "^4.0.0",
     "one-by-one": "^2.0.0",
     "parent-search": "^1.1.0",


### PR DESCRIPTION
Fixed #29 by adding `color=never` to the `git log` child process.

Also, by using the latest release of [`oargv`](https://github.com/IonicaBizau/node-oargv), I cleaned up the code which generates the duplicated `--author` options (now that's built in the `oargv` core). :tada: 