### PR TITLE
git-stats-importer 2.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,39 @@
-# `$ git-stats-importer` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/git-stats-importer.svg)](https://www.npmjs.com/package/git-stats-importer) [![Downloads](https://img.shields.io/npm/dt/git-stats-importer.svg)](https://www.npmjs.com/package/git-stats-importer) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+
+# `$ git-stats-importer`
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/git-stats-importer.svg)](https://www.npmjs.com/package/git-stats-importer) [![Downloads](https://img.shields.io/npm/dt/git-stats-importer.svg)](https://www.npmjs.com/package/git-stats-importer) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Imports your commits from a repository into git-stats history.
 
 This tool imports commits into the [`git-stats`](https://github.com/IonicaBizau/git-stats) commit history. If you like to import all your commits from BitBucket and GitHub, check out the [Repository Downloader project](https://github.com/IonicaBizau/repository-downloader).
 
-## Installation
+## :cloud: Installation
 
 You can install the package globally and use it as command line tool:
+
 
 ```sh
 $ npm i -g git-stats-importer
 ```
 
+
 Then, run `git-stats-importer --help` and see what the CLI tool can do.
 
-```sh
+
+```
 $ git-stats-importer --help
 Usage: git-stats-importer [options]
 
 Options:
-  -f, --find-repos <path>  If this option is provided, the importer will    
-                           search for repositories in the provided path     
-                           (recursively).                                   
-  -d, --delete             Delete the commits from selected repositories.   
+  -f, --find-repos <path>  If this option is provided, the importer will
+                           search for repositories in the provided path
+                           (recursively).
+  -d, --delete             Delete the commits from selected repositories.
   -e, --emails <emails>    Comma separated emails you want to include in the
-                           import process. By default it's the              
-                           $GIT_AUTHOR_EMAIL value.                         
-  -h, --help               Displays this help.                              
-  -v, --version            Displays version information.                    
+                           import process. By default it's the
+                           $GIT_AUTHOR_EMAIL value.
+  -h, --help               Displays this help.
+  -v, --version            Displays version information.
 
 Examples:
   git-stats-importer # imports the commits from the current repository
@@ -38,7 +44,8 @@ Examples:
 Documentation can be found at https://github.com/IonicaBizau/git-stats-importer
 ```
 
-## Example
+## :clipboard: Example
+
 
 Here is an example how to use this package as library. To install it locally, as library, you can do that using `npm`:
 
@@ -46,9 +53,11 @@ Here is an example how to use this package as library. To install it locally, as
 $ npm i --save git-stats-importer
 ```
 
+
+
 ```js
 // Dependencies
-var GitStatsImporter = require("../");
+var GitStatsImporter = require("git-stats-importer");
 
 // Start importing
 var importer = GitStatsImporter({
@@ -95,17 +104,15 @@ importer.on("finish", function (data) {
 });
 ```
 
-## Documentation
+## :memo: Documentation
 
 For full API reference, see the [DOCUMENTATION.md][docs] file.
 
-## How to contribute
+## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## Where is this library used?
-If you are using this library in one of your projects, add it in this list. :sparkles:
 
-## License
+## :scroll: License
 
 [MIT][license] © [Ionică Bizău][website]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-stats-importer",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Imports your commits from a repository into git-stats history.",
   "main": "lib/index.js",
   "bin": {
@@ -60,6 +60,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.