### PR TITLE
Forbid commit hash abbreviation (fix #48)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ Importer.prototype.stream = function () {
       , args = OArgv({
             author: this.emails
           , color: "never"
+          , abbrev: 40
           , __: "="
         }, "log")
       , pr = Spawn(


### PR DESCRIPTION
Fix #48, allowing git-stats-importer to work in environments with abbreviation enabled