### PR TITLE
add `--date=iso-strict` to git log to ensure ISO8601 date parsing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,9 @@ Importer.prototype.stream = function () {
           , color: "never"
           , __: "="
         }, "log")
-      , pr = Spawn(
+      ;
+    args.push('--date=iso-strict');
+    var pr = Spawn(
             "git"
           , args
           , { cwd: this.path }


### PR DESCRIPTION
Prevents "Invalid date" entries in .git-stats by forcing git log to output commit dates in ISO8601 format, so Node.js can reliably parse and group imported commits.

bug details:

<img width="1752" alt="image" src="https://github.com/user-attachments/assets/9e41cd7e-53a4-4e0b-8432-c2d467f89585" />

---

code change verification

<img width="1748" alt="image" src="https://github.com/user-attachments/assets/00f93739-5249-4afd-99a0-0dfeb22ae222" />
